### PR TITLE
Remove the global temp file naming and duplicate code.

### DIFF
--- a/README
+++ b/README
@@ -24,7 +24,6 @@ The user MUST edit the script file to add in
     * location of hipchat-cli
     * a user name for display in hipchat
     * location of svnlook command. In RedHat/CentOS /usr/bin/svnlook
-    * location of temp file. 
 
 To test:
     1) Edit script file

--- a/post-commit
+++ b/post-commit
@@ -28,8 +28,8 @@ SUB=""
 # svnlook location
 LOOK="<svnlook LOCATION>"
 
-# Temp file location and name
-HCTMP="<TMP FILE>"
+# Temp file location and name, automatically generate by file path.
+HCTMP="/tmp/`cksum $0 | cut -d " " -f 1`.tmp"
 
 ##############################################################
 ##############################################################

--- a/post-commit
+++ b/post-commit
@@ -28,9 +28,6 @@ SUB=""
 # svnlook location
 LOOK="<svnlook LOCATION>"
 
-# Temp file location and name, automatically generate by file path.
-HCTMP="/tmp/`cksum $0 | cut -d " " -f 1`.tmp"
-
 ##############################################################
 ##############################################################
 ############ Edit below at your own risk #####################
@@ -55,6 +52,10 @@ fi
 
 # Setup the actual post-commit process
 post(){
+
+# Temp file location and name, automatically generate by file path.
+  HCTMP=`mktemp`
+
   echo "`${WHO}` updated ${REPO} to Rev: ${REV}" > ${HCTMP}
   echo "`${CMT}`" >> ${HCTMP}
   echo "The following list of files were changed:" >> ${HCTMP}
@@ -65,15 +66,13 @@ then
 CHKSUB=`grep ${SUB} ${HCTMP} | wc -l` 
   if [ $CHKSUB -gt 0 ]
   then
-  cat ${HCTMP} | ${HCCTL}
-  rm -f ${HCTMP}
-  else
-  rm -f ${HCTMP}
+    cat ${HCTMP} | ${HCCTL}
   fi
 else
   cat ${HCTMP} | ${HCCTL}
-  rm -f ${HCTMP}
 fi
+
+rm -f ${HCTMP}
 }
 
 # Make things tight


### PR DESCRIPTION
The tmp file can be created automatically.
Because I used it on multiple subversion repos, doing that I do not to change the tmp file for every repos.
